### PR TITLE
Faker

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ available to you right from the start, as if you are using vscode.
 32. Cron edit and explain
 33. UUID generator
 34. Regex Tester
+35. Generate mock data with Faker
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@aptabase/tauri": "^0.4.1",
+    "@faker-js/faker": "^8.4.1",
     "@hello-pangea/dnd": "^16.6.0",
     "@loadable/component": "^5.16.3",
     "@mantine/charts": "^7.7.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,6 +70,7 @@ const PdfReader = loadable(() => import("./Features/pdf/PdfReader"));
 const Cron = loadable(() => import("./Features/cron/Cron"));
 const Ids = loadable(() => import("./Features/ids/Ids"));
 const Compress = loadable(() => import("./Features/text/TextCompress"));
+const Faker = loadable(() => import("./Features/faker/Faker"));
 
 const shortCuts = [
   {
@@ -229,6 +230,7 @@ function App() {
             <Route path="/cron" element={<Cron />}></Route>
             <Route path="/ids" element={<Ids />}></Route>
             <Route path="/compress" element={<Compress />}></Route>
+            <Route path="/faker" element={<Faker />}></Route>
           </Routes>
         </Group>
       </Box>

--- a/src/Features/faker/Faker.tsx
+++ b/src/Features/faker/Faker.tsx
@@ -173,7 +173,7 @@ export default function Faker() {
    * @returns 
    */
   const objectFromFields = (fields: Field[], locale: string | null) => {
-    let obj: { [key: string]: any } = {};
+    let obj: { [key: string]: string } = {};
     fields.forEach(f => {
       try {
         obj[f.fieldName] = getMockData(f.category, f.dataType, locale);

--- a/src/Features/faker/Faker.tsx
+++ b/src/Features/faker/Faker.tsx
@@ -9,7 +9,8 @@ import {
   TextInput,
   Divider,
   rem,
-  Text
+  Text,
+  NumberInput
 } from "@mantine/core";
 import { FakerInput } from "./FakerInput"
 import { useCallback, useEffect, useState } from "react";
@@ -46,12 +47,11 @@ const outputFormats = [
  * 
  * @param category The category for which the fake data falls within
  * @param dataType The specific data type to be fakes
+ * @param locale The locale to be used for generating mock data
  * @returns The faker generated data
  */
 const getMockData = (category: string, dataType: string, locale: string | null): any => {
-  const actualLocale = locale || 'en_US';
-  console.log(`mocking: ${actualLocale}`);
-
+  const actualLocale = locale || 'en_US'; // TODO: Can't seem to get faker to work
   if ((faker as any)[category] && typeof (faker as any)[category][dataType] === 'function') {
     return (faker as any)[category][dataType]();
   } else {
@@ -79,10 +79,6 @@ export default function Faker() {
   const [output, setOutput] = useState<string>();
 
   // #region Change Handlers
-  const rowCountChange = (event: any) => {
-    setRowCount(parseInt(event.target.value)) // TODO: Check non-integer values (error)
-  }
-
   const tableNameChange = (event: any) => {
     setTableName(event.target.value);
   }
@@ -131,7 +127,6 @@ export default function Faker() {
    * Determines the output format and uses some helpers and one js-yaml library
    */
   const generate = useCallback(async () => {
-    console.log("locale:" + fakerLocale)
     const result = validateFields();
     if (!result.valid) {
       showWarning("Validation Error", result.message);
@@ -222,7 +217,6 @@ export default function Faker() {
         showError("Faker Error", message);
       }
     });
-    console.log(line);
     return line.slice(0, -1); // remove trailing delimeter
   };
 
@@ -318,7 +312,7 @@ export default function Faker() {
               }))}
             />
             <Text># Rows: </Text>
-            <TextInput onChange={rowCountChange} defaultValue={rowCount} />
+            <NumberInput onChange={(value: string | number) => setRowCount(Number(value))} defaultValue={rowCount} />
             <Text>Format: </Text>
             <Select
               value={outputFormat}
@@ -353,7 +347,6 @@ export default function Faker() {
                     </ActionIcon>
                   </Group>
                 ))}
-                <pre>{JSON.stringify(fields, null, 2)}</pre>
               </ScrollArea.Autosize>
               <Button onClick={addField}>Add Another Field</Button>
             </Stack>

--- a/src/Features/faker/Faker.tsx
+++ b/src/Features/faker/Faker.tsx
@@ -1,0 +1,81 @@
+import classes from "./styles.module.css";
+
+import {
+  Button,
+  Group,
+  JsonInput,
+  Select,
+  Stack,
+  TextInput,
+} from "@mantine/core";
+import FakerInput from "./FakerInput"
+import { useState } from "react";
+import { faker } from "@faker-js/faker";
+import { Monaco } from "../../Components/MonacoWrapper";
+
+const formats = [
+  { format: "json", label: "JSON" },
+  { format: "sql", label: "SQL" },
+];
+
+const generateRandomData = (categoryName: string, subsetName: string): any => {
+  if ((faker as any)[categoryName] && typeof (faker as any)[categoryName][subsetName] === 'function') {
+    return (faker as any)[categoryName][subsetName]();
+  } else {
+    throw new Error(`Invalid category or subset: ${categoryName}.${subsetName}`);
+  }
+};
+
+interface Field {
+  fieldName: string,
+  category: string,
+  dataType: string,
+  expression?: {},
+}
+
+export default function Faker() {
+  const [lang, setLang] = useState<string | null>("json");
+
+  const calcOP = async (e: string) => { };
+
+
+  return (
+    <Stack h="100%">
+      <Group className={classes.parent}>
+        <Stack style={{ height: "100%", width: "100%" }}>
+          <Group>
+            {" "}
+            <Select
+              value={lang}
+              allowDeselect={false}
+              onChange={setLang}
+              data={formats.map((l) => ({
+                value: l.format,
+                label: l.label,
+              }))}
+            />
+            <Button onClick={() => calcOP('')}>Generate</Button>
+          </Group>
+          <Group wrap="nowrap" style={{ height: "100%", width: "100%" }}>
+            <Stack justify="flex-start" h="100%">
+              <FakerInput />
+            </Stack>
+            <Monaco
+              height="100%"
+              width="55%"
+              language={
+                formats.find((l) => l.format === lang)?.format || "text"
+              }
+              value={'{}'}
+              extraOptions={{
+                readOnly: true,
+              }}
+            />
+          </Group>
+        </Stack>
+      </Group>
+    </Stack>
+  );
+}
+
+// todo: impl lang specific toggle options, sample above

--- a/src/Features/faker/Faker.tsx
+++ b/src/Features/faker/Faker.tsx
@@ -1,21 +1,37 @@
 import classes from "./styles.module.css";
-
 import {
+  ActionIcon,
   Button,
   Group,
-  JsonInput,
+  ScrollArea,
   Select,
   Stack,
   TextInput,
+  Divider,
+  rem,
+  Text
 } from "@mantine/core";
-import FakerInput from "./FakerInput"
+import { FakerInput } from "./FakerInput"
 import { useState } from "react";
 import { faker } from "@faker-js/faker";
 import { Monaco } from "../../Components/MonacoWrapper";
+import {
+  MdOutlineRemove,
+  MdOutlineClose,
+  MdOutlineWarning,
+  MdOutlineCheck,
+} from "react-icons/md";
+import { notifications } from "@mantine/notifications";
+import { allLocales } from "@faker-js/faker";
+
+const errorIcon = <MdOutlineClose style={{ width: rem(20), height: rem(20) }} />;
+const successIcon = <MdOutlineCheck style={{ width: rem(20), height: rem(20) }} />;
+const warningIcon = <MdOutlineWarning style={{ width: rem(20), height: rem(20) }} />;
 
 const formats = [
   { format: "json", label: "JSON" },
   { format: "sql", label: "SQL" },
+  { format: "csv", label: "CSV" },
 ];
 
 const generateRandomData = (categoryName: string, subsetName: string): any => {
@@ -26,45 +42,145 @@ const generateRandomData = (categoryName: string, subsetName: string): any => {
   }
 };
 
+export const getFakeLocales = (): string[] => {
+  return Object.keys(allLocales);
+};
+
 interface Field {
   fieldName: string,
   category: string,
   dataType: string,
-  expression?: {},
 }
 
 export default function Faker() {
-  const [lang, setLang] = useState<string | null>("json");
+  const [fakeLocale, setFakeLocale] = useState<string>('en_US');
+  const [format, setFormat] = useState<string | null>("json");
+  const [fields, setFields] = useState<Field[]>([{ fieldName: '', category: '', dataType: '' }]);
+  const [tableName, setTableName] = useState<string>('table-1');
+  const [rowCount, setRowCount] = useState<number>(10);
 
-  const calcOP = async (e: string) => { };
+  const handleAdd = () => {
+    setFields([...fields, { fieldName: '', category: '', dataType: '' }]);
+  };
 
+  const handleRemove = (index: number) => {
+    setFields(fields.filter((_, i) => i !== index));
+  };
+
+  const handleFieldNameChange = (index: number, name: string | null) => {
+    const updatedFields = [...fields];
+    updatedFields[index].fieldName = name || '';
+    setFields(updatedFields);
+  };
+
+  const handleCategoryChange = (index: number, category: string | null) => {
+    const updatedFields = [...fields];
+    updatedFields[index].category = category || '';
+    setFields(updatedFields);
+  };
+
+  const handleSubsetChange = (index: number, dataType: string | null) => {
+    const updatedFields = [...fields];
+    updatedFields[index].dataType = dataType || '';
+    setFields(updatedFields);
+  };
+
+  function handleGenerate() {
+    if (validateFields()) {
+      notifications.show({
+        icon: successIcon,
+        title: 'Success',
+        message: 'Generated.',
+        color: "green",
+      })
+    }
+  };
+
+  const objectFromField = (field: Field) => {
+
+  };
+
+  const validateFields = () => {
+    if (fields.length < 1) {
+      notifications.show({
+        icon: warningIcon,
+        title: 'Warning',
+        message: 'Add at least on field.',
+        color: "orange",
+      })
+      return false;
+    }
+    fields.forEach((field, index) => {
+      if (!field.fieldName || field.category || field.dataType) {
+        notifications.show({
+          icon: warningIcon,
+          title: 'Warning',
+          message: `Field ${index + 1} is not valid. All properties are required.`,
+          color: "orange",
+        })
+        return false
+      }
+    });
+    return true;
+  };
 
   return (
     <Stack h="100%">
       <Group className={classes.parent}>
         <Stack style={{ height: "100%", width: "100%" }}>
-          <Group>
-            {" "}
+          <Group >
+            <Text>Locale: </Text>
             <Select
-              value={lang}
+              value={fakeLocale}
+              data={getFakeLocales().map((l) => ({
+                value: l,
+                label: l,
+              }))}
+            />
+            <Text># Rows: </Text>
+            <TextInput value={rowCount} />
+            <Text>Format: </Text>
+            <Select
+              value={format}
               allowDeselect={false}
-              onChange={setLang}
+              onChange={setFormat}
               data={formats.map((l) => ({
                 value: l.format,
                 label: l.label,
               }))}
             />
-            <Button onClick={() => calcOP('')}>Generate</Button>
+            {format === 'sql' ? <Group><Text>Format: </Text> <TextInput value={tableName} placeholder="Table name" /></Group> : null}
+            <Button onClick={handleGenerate}>Generate</Button>
           </Group>
+          <Divider size="xs" my="xs" />
           <Group wrap="nowrap" style={{ height: "100%", width: "100%" }}>
-            <Stack justify="flex-start" h="100%">
-              <FakerInput />
+            <Stack justify="flex-start" h="100%" w="45%">
+              <ScrollArea.Autosize mah="90%" type="always" >
+                {fields.map((item, index) => (
+                  <Group key={index} style={{ marginBottom: '1rem' }}>
+                    <Text>{index + 1}</Text>
+                    <FakerInput
+                      fieldName={item.fieldName}
+                      category={item.category}
+                      dataType={item.dataType}
+                      onFieldNameChange={(fieldName: string | null) => handleFieldNameChange(index, fieldName)}
+                      onCategoryChange={(category: string | null) => handleCategoryChange(index, category)}
+                      onDataTypeChange={(subset: string | null) => handleSubsetChange(index, subset)}
+                    />
+                    <ActionIcon onClick={() => handleRemove(index)} variant="default" aria-label="Settings">
+                      <MdOutlineRemove style={{ width: '70%', height: '70%' }} />
+                    </ActionIcon>
+                  </Group>
+                ))}
+                {/* <pre>{JSON.stringify(fields, null, 2)}</pre> For debugging */}
+              </ScrollArea.Autosize>
+              <Button onClick={handleAdd}>Add Another Field</Button>
             </Stack>
             <Monaco
               height="100%"
               width="55%"
               language={
-                formats.find((l) => l.format === lang)?.format || "text"
+                formats.find((l) => l.format === format)?.format || "text"
               }
               value={'{}'}
               extraOptions={{
@@ -77,5 +193,3 @@ export default function Faker() {
     </Stack>
   );
 }
-
-// todo: impl lang specific toggle options, sample above

--- a/src/Features/faker/Faker.tsx
+++ b/src/Features/faker/Faker.tsx
@@ -26,19 +26,32 @@ import { allLocales } from "@faker-js/faker";
 import YAML from "js-yaml";
 import { delimiter } from "@tauri-apps/api/path";
 import { event } from "@tauri-apps/api";
+import { assert } from "quicktype-core";
 
 const errorIcon = <MdOutlineClose style={{ width: rem(20), height: rem(20) }} />;
-const successIcon = <MdOutlineCheck style={{ width: rem(20), height: rem(20) }} />;
 const warningIcon = <MdOutlineWarning style={{ width: rem(20), height: rem(20) }} />;
 
-const formats = [
+/**
+ * Supported output formats
+ */
+const outputFormats = [
   { format: "json", label: "JSON" },
   { format: "yaml", label: "YAML" },
   { format: "sql", label: "SQL" },
   { format: "csv", label: "CSV" },
 ];
 
-const getMockData = (category: string, dataType: string): any => {
+/**
+ * Generates a mock data using @faker-js/faker based on given data category and type
+ * 
+ * @param category The category for which the fake data falls within
+ * @param dataType The specific data type to be fakes
+ * @returns The faker generated data
+ */
+const getMockData = (category: string, dataType: string, locale: string | null): any => {
+  const actualLocale = locale || 'en_US';
+  console.log(`mocking: ${actualLocale}`);
+
   if ((faker as any)[category] && typeof (faker as any)[category][dataType] === 'function') {
     return (faker as any)[category][dataType]();
   } else {
@@ -46,7 +59,7 @@ const getMockData = (category: string, dataType: string): any => {
   }
 };
 
-export const getFakeLocales = (): string[] => {
+const getFakerLocales = (): string[] => {
   return Object.keys(allLocales);
 };
 
@@ -57,86 +70,118 @@ interface Field {
 }
 
 export default function Faker() {
-  const [fakeLocale, setFakeLocale] = useState<string>('en_US');
-  const [format, setFormat] = useState<string | null>("json");
+  const [fakerLocale, setFakerLocale] = useState<string | null>('en_US');
+  const [outputFormat, setOutputFormat] = useState<string | null>("json");
   const [fields, setFields] = useState<Field[]>([{ fieldName: 'id', category: 'datatype', dataType: 'uuid' }]);
   const [tableName, setTableName] = useState<string>('table-1');
   const [rowCount, setRowCount] = useState<number>(10);
   const [csvDelimiter, setCsvDelimiter] = useState<string>(",");
   const [output, setOutput] = useState<string>();
 
+  // #region Change Handlers
+  const rowCountChange = (event: any) => {
+    setRowCount(parseInt(event.target.value)) // TODO: Check non-integer values (error)
+  }
+
   const tableNameChange = (event: any) => {
-    console.log(event.target.value);
     setTableName(event.target.value);
   }
 
-  const rowCountChange = (event: any) => {
-    console.log(event.target.value);
-    setRowCount(parseInt(event.target.value)) // Check non integer values
-  }
-
   const csvDelimiterChange = (event: any) => {
-    console.log(event.target.value);
     setCsvDelimiter(event.target.value);
   }
 
-  const addField = () => {
-    setFields([...fields, { fieldName: '', category: '', dataType: '' }]);
-  };
-
-  const handleRemove = (index: number) => {
-    setFields(fields.filter((_, i) => i !== index));
-  };
-
-  const handleFieldNameChange = (index: number, name: string | null) => {
+  const fieldNameChange = (index: number, name: string | null) => {
     const updatedFields = [...fields];
     updatedFields[index].fieldName = name || '';
     setFields(updatedFields);
   };
 
-  const handleCategoryChange = (index: number, category: string | null) => {
+  const fieldCategoryChange = (index: number, category: string | null) => {
     const updatedFields = [...fields];
     updatedFields[index].category = category || '';
     setFields(updatedFields);
   };
 
-  const handleSubsetChange = (index: number, dataType: string | null) => {
+  const fieldDataTypeChange = (index: number, dataType: string | null) => {
     const updatedFields = [...fields];
     updatedFields[index].dataType = dataType || '';
     setFields(updatedFields);
   };
+  // #endregion
 
+  /**
+   * Adds a new field to the list of fields along with a corresponding FakeInput Compponent
+   */
+  const addField = () => {
+    setFields([...fields, { fieldName: '', category: '', dataType: '' }]);
+  };
+
+  /**
+   * Removes a specific FakerInput component form view and corresponding Field from list of fields
+   * 
+   * @param index The index of the field to remove
+   */
+  const removeField = (index: number) => {
+    setFields(fields.filter((_, i) => i !== index));
+  };
+
+  /**
+   * Generates the mock data in the desired output
+   * Determines the output format and uses some helpers and one js-yaml library
+   */
   const generate = useCallback(async () => {
-    if (validateFields()) {
-      if (format === "json" || format === "yaml") {
-        let data = [];
-        for (let i = 0; i < rowCount; i++) {
-          data.push(objectFromFields(fields))
-        }
-        if (format !== "yaml") {
-          let input = JSON.stringify(data, undefined, 2);
-          setOutput(input);
-          return;
-        }
-        setOutput(YAML.dump(data, {
-          indent: 2,
-        }))
-      }
-      if (format === "csv") {
-        let output = ""
-        for (let i = 0; i < rowCount; i++) {
-          output += csvRowFromFields(fields, csvDelimiter) + "\n";
-        }
-        setOutput(output);
-      }
+    console.log("locale:" + fakerLocale)
+    const result = validateFields();
+    if (!result.valid) {
+      showWarning("Validation Error", result.message);
+      return;
     }
-  }, [rowCount, fields, format, csvDelimiter]);
 
-  const objectFromFields = (fields: Field[]) => {
+    if (outputFormat === "json" || outputFormat === "yaml") {
+      let data = [];
+      for (let i = 0; i < rowCount; i++) {
+        data.push(objectFromFields(fields, fakerLocale))
+      }
+      if (outputFormat !== "yaml") {
+        let input = JSON.stringify(data, undefined, 2);
+        setOutput(input);
+        return;
+      }
+      setOutput(YAML.dump(data, {
+        indent: 2,
+      }))
+    }
+    if (outputFormat === "csv") {
+      let output = ""
+      for (let i = 0; i < rowCount; i++) {
+        output += csvRowFromFields(fields, csvDelimiter, fakerLocale) + "\n";
+      }
+      setOutput(output);
+      return;
+    }
+    if (outputFormat == "sql") {
+      let output = ""
+      for (let i = 0; i < rowCount; i++) {
+        output += sqlInsertFromFields(tableName, fields, fakerLocale) + "\n";
+      }
+      setOutput(output);
+      return;
+    }
+  }, [rowCount, fields, outputFormat, csvDelimiter, tableName, fakerLocale]);
+
+
+  /**
+   * Creates a Javscript object with mock property values from a list of field
+   * 
+   * @param fields 
+   * @returns 
+   */
+  const objectFromFields = (fields: Field[], locale: string | null) => {
     let obj: { [key: string]: any } = {};
     fields.forEach(f => {
       try {
-        obj[f.fieldName] = getMockData(f.category, f.dataType);
+        obj[f.fieldName] = getMockData(f.category, f.dataType, locale);
       } catch (error) {
         let message
         if (error instanceof Error) message = error.message
@@ -148,7 +193,7 @@ export default function Faker() {
   };
 
   /**
-   * Simply quotes a string of it contains the CSV delimeter
+   * Simply quotes a string if it contains the CSV delimeter
    * 
    * @param value The string value to be made safe
    * @param delimeter The deleimeter to check for in the string
@@ -158,11 +203,18 @@ export default function Faker() {
     return value;
   };
 
-  const csvRowFromFields = (fields: Field[], delimeter: string) => {
+  /**
+   * Creates a CSV row with mock data from a list of fields
+   * 
+   * @param fields The list of fields to be comma-separated
+   * @param delimeter Character to distinguish columns
+   * @returns 
+   */
+  const csvRowFromFields = (fields: Field[], delimeter: string, locale: string | null) => {
     let line: string = "";
     fields.forEach(f => {
       try {
-        line += `${csvSafe(getMockData(f.category, f.dataType), delimeter)} ${delimeter}`;
+        line += `${csvSafe(getMockData(f.category, f.dataType, locale), delimeter)} ${delimeter}`;
       } catch (error) {
         let message
         if (error instanceof Error) message = error.message
@@ -174,6 +226,58 @@ export default function Faker() {
     return line.slice(0, -1); // remove trailing delimeter
   };
 
+  const sqlInsertFromFields = (tableName: string, fields: Field[], locale: string | null) => {
+    let obj = objectFromFields(fields, locale);
+    //array.map(item => `'${item}'`).join(delimiter);
+    return `
+    INSERT INTO ${tableName} (${Object.keys(obj).join(',')}) 
+    VALUES(${Object.values(obj).map(item => `'${item}'`).join(',')});`;
+  };
+
+  /**
+   * Checks is a not empty, undefined or null
+   * 
+   * @param val The string to validate
+   * @returns boolean result of validation
+   */
+  const validString = (val: string | null) => {
+    return ![null, undefined, ''].includes(val);
+  }
+
+  type ValidResult = { valid: true; };
+  type InvalidResult = { valid: false; message: string; }; // Error message needed only if validation fails
+  type ValidationResult = ValidResult | InvalidResult;
+
+  /**
+   * Validate the list of fields
+   * Check that the list is not empty and that each field's entries are non-empty strings
+   * 
+   * @returns ValidationResult Result of the validation. It included and error message if validation is false
+   */
+  const validateFields = (): ValidationResult => {
+    if (fields.length < 1) {
+      return {
+        valid: false,
+        message: 'Add at least on field.'
+      }
+    }
+    fields.forEach((field, index) => {
+      if (!validString(field.fieldName) || !validString(field.category) || !validString(field.dataType)) {
+        return {
+          valid: false,
+          message: `Field ${index + 1} is not valid. All properties are required.`,
+        }
+      }
+    });
+    return { valid: true };
+  };
+
+  /**
+   * Shows error notification in a toast dialog
+   * 
+   * @param title The title of the toast
+   * @param message Message to be included the content of the notification
+   */
   const showError = (title: string, message: string) => {
     notifications.show({
       icon: errorIcon,
@@ -183,33 +287,20 @@ export default function Faker() {
     })
   }
 
-  const validInput = (val: string) => {
-    return ![null, undefined, ''].includes(val);
+  /**
+ * Shows warning notification in a toast dialog
+ * 
+ * @param title The title of the toast
+ * @param message Message to be included the content of the notification
+ */
+  const showWarning = (title: string, message: string) => {
+    notifications.show({
+      icon: warningIcon,
+      title: title,
+      message: message,
+      color: "orange",
+    })
   }
-
-  const validateFields = () => {
-    if (fields.length < 1) {
-      notifications.show({
-        icon: warningIcon,
-        title: 'Warning',
-        message: 'Add at least on field.',
-        color: "orange",
-      })
-      return false;
-    }
-    fields.forEach((field, index) => {
-      if (!validInput(field.fieldName) || !validInput(field.category) || !validInput(field.dataType)) {
-        notifications.show({
-          icon: warningIcon,
-          title: 'Warning',
-          message: `Field ${index + 1} is not valid. All properties are required.`,
-          color: "orange",
-        })
-        return false
-      }
-    });
-    return true;
-  };
 
   return (
     <Stack h="100%">
@@ -218,8 +309,10 @@ export default function Faker() {
           <Group >
             <Text>Locale: </Text>
             <Select
-              value={fakeLocale}
-              data={getFakeLocales().map((l) => ({
+              value={fakerLocale}
+              allowDeselect={false}
+              onChange={setFakerLocale}
+              data={getFakerLocales().map((l) => ({
                 value: l,
                 label: l,
               }))}
@@ -228,16 +321,16 @@ export default function Faker() {
             <TextInput onChange={rowCountChange} defaultValue={rowCount} />
             <Text>Format: </Text>
             <Select
-              value={format}
+              value={outputFormat}
               allowDeselect={false}
-              onChange={setFormat}
-              data={formats.map((l) => ({
+              onChange={setOutputFormat}
+              data={outputFormats.map((l) => ({
                 value: l.format,
                 label: l.label,
               }))}
             />
-            {format === 'sql' ? <Group><Text>Table Name: </Text> <TextInput onChange={tableNameChange} defaultValue={tableName} /></Group> : null}
-            {format === 'csv' ? <Group><Text>CSV Delimiter: </Text> <TextInput onChange={csvDelimiterChange} defaultValue={csvDelimiter} /></Group> : null}
+            {outputFormat === 'sql' ? <Group><Text>Table Name: </Text> <TextInput onChange={tableNameChange} defaultValue={tableName} /></Group> : null}
+            {outputFormat === 'csv' ? <Group><Text>CSV Delimiter: </Text> <TextInput onChange={csvDelimiterChange} defaultValue={csvDelimiter} /></Group> : null}
             <Button onClick={generate}>Generate</Button>
           </Group>
           <Divider size="xs" my="xs" />
@@ -251,11 +344,11 @@ export default function Faker() {
                       fieldName={item.fieldName}
                       category={item.category}
                       dataType={item.dataType}
-                      onFieldNameChange={(fieldName: string | null) => handleFieldNameChange(index, fieldName)}
-                      onCategoryChange={(category: string | null) => handleCategoryChange(index, category)}
-                      onDataTypeChange={(subset: string | null) => handleSubsetChange(index, subset)}
+                      onFieldNameChange={(fieldName: string | null) => fieldNameChange(index, fieldName)}
+                      onCategoryChange={(category: string | null) => fieldCategoryChange(index, category)}
+                      onDataTypeChange={(subset: string | null) => fieldDataTypeChange(index, subset)}
                     />
-                    <ActionIcon onClick={() => handleRemove(index)} variant="default" aria-label="Settings">
+                    <ActionIcon onClick={() => removeField(index)} variant="default" aria-label="Settings">
                       <MdOutlineRemove style={{ width: '70%', height: '70%' }} />
                     </ActionIcon>
                   </Group>
@@ -268,7 +361,7 @@ export default function Faker() {
               height="100%"
               width="55%"
               language={
-                formats.find((l) => l.format === format)?.format || "text"
+                outputFormats.find((l) => l.format === outputFormat)?.format || "text"
               }
               value={output}
               extraOptions={{

--- a/src/Features/faker/FakerInput.tsx
+++ b/src/Features/faker/FakerInput.tsx
@@ -26,8 +26,12 @@ const getCategoriesAndSubsets = () => {
 
 const getCategoryNames = (): string[] => {
     const categories = getCategoriesAndSubsets();
-    return Object.keys(categories);
+    return Object.keys(categories).filter((value) => {
+        return value != "_randomizer" && value != "helpers";
+    });
 };
+
+console.log(getCategoryNames())
 
 const getDataTypesForCategory = (categoryName: string): string[] => {
     const categories = getCategoriesAndSubsets();

--- a/src/Features/faker/FakerInput.tsx
+++ b/src/Features/faker/FakerInput.tsx
@@ -1,0 +1,73 @@
+import {
+    Button,
+    Group,
+    Select,
+    Stack,
+    TextInput,
+} from "@mantine/core";
+import { useEffect, useState } from "react";
+import { faker } from "@faker-js/faker";
+
+// Function to get categories and their subsets dynamically
+const getCategoriesAndSubsets = () => {
+    const categories: { [key: string]: string[] } = {};
+
+    for (const categoryKey in faker) {
+        if (typeof (faker as any)[categoryKey] === 'object' && (faker as any)[categoryKey] !== null) {
+            const subsets = Object.keys((faker as any)[categoryKey])
+                .filter(subsetKey => typeof (faker as any)[categoryKey][subsetKey] === 'function');
+            if (subsets.length > 0) {
+                categories[categoryKey] = subsets;
+            }
+        }
+    }
+
+    return categories;
+};
+
+const getCategoryNames = (): string[] => {
+    const categories = getCategoriesAndSubsets();
+    return Object.keys(categories);
+};
+
+// Function to get subsets for a given category name
+const getSubsetsForCategory = (categoryName: string): string[] => {
+    const categories = getCategoriesAndSubsets();
+    return categories[categoryName] || [];
+};
+
+console.log(getCategoryNames());
+//console.log(getSubsetsForCategory("animal"));
+
+export default function FakerInput() {
+    const [category, setCategory] = useState<string | null>("datatype");
+    const [categoryTypes, setCategoryTypes] = useState<string[]>([]);
+    const [dataType, setDataType] = useState<string | null>("uuid");
+
+    useEffect(() => {
+        if (category) {
+            const subsets = getSubsetsForCategory(category);
+            setCategoryTypes(subsets);
+            setDataType(null); // Reset subset selection when category changes
+        }
+    }, [category]);
+
+    return (
+        <Group>
+            <TextInput placeholder="Field name" />
+            <Select
+                value={category}
+                allowDeselect={false}
+                onChange={setCategory}
+                placeholder="Category"
+                data={getCategoryNames()} />
+            <Select
+                value={dataType}
+                onChange={setDataType}
+                placeholder="Subset"
+                data={categoryTypes.map(name => ({ value: name, label: name }))}
+                disabled={!category}
+            />
+        </Group>
+    );
+}

--- a/src/Features/faker/FakerInput.tsx
+++ b/src/Features/faker/FakerInput.tsx
@@ -1,21 +1,20 @@
-import {
-    Button,
-    Group,
-    Select,
-    Stack,
-    TextInput,
-} from "@mantine/core";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { faker } from "@faker-js/faker";
+import { Group, Select, TextInput } from "@mantine/core";
 
 // Function to get categories and their subsets dynamically
 const getCategoriesAndSubsets = () => {
     const categories: { [key: string]: string[] } = {};
 
     for (const categoryKey in faker) {
-        if (typeof (faker as any)[categoryKey] === 'object' && (faker as any)[categoryKey] !== null) {
-            const subsets = Object.keys((faker as any)[categoryKey])
-                .filter(subsetKey => typeof (faker as any)[categoryKey][subsetKey] === 'function');
+        if (
+            typeof (faker as any)[categoryKey] === "object" &&
+            (faker as any)[categoryKey] !== null
+        ) {
+            const subsets = Object.keys((faker as any)[categoryKey]).filter(
+                (subsetKey) =>
+                    typeof (faker as any)[categoryKey][subsetKey] === "function"
+            );
             if (subsets.length > 0) {
                 categories[categoryKey] = subsets;
             }
@@ -30,44 +29,61 @@ const getCategoryNames = (): string[] => {
     return Object.keys(categories);
 };
 
-// Function to get subsets for a given category name
-const getSubsetsForCategory = (categoryName: string): string[] => {
+const getDataTypesForCategory = (categoryName: string): string[] => {
     const categories = getCategoriesAndSubsets();
     return categories[categoryName] || [];
 };
 
-console.log(getCategoryNames());
-//console.log(getSubsetsForCategory("animal"));
+interface FakeInputProps {
+    fieldName: string;
+    category: string;
+    dataType: string;
+    onFieldNameChange: (category: string | null) => void;
+    onCategoryChange: (category: string | null) => void;
+    onDataTypeChange: (dataType: string | null) => void;
+}
 
-export default function FakerInput() {
-    const [category, setCategory] = useState<string | null>("datatype");
-    const [categoryTypes, setCategoryTypes] = useState<string[]>([]);
-    const [dataType, setDataType] = useState<string | null>("uuid");
+export const FakerInput: React.FC<FakeInputProps> = ({
+    fieldName,
+    category,
+    dataType,
+    onFieldNameChange,
+    onCategoryChange,
+    onDataTypeChange,
+}) => {
+    const [dataTypes, setDataTypes] = useState<string[]>([]);
 
     useEffect(() => {
         if (category) {
-            const subsets = getSubsetsForCategory(category);
-            setCategoryTypes(subsets);
-            setDataType(null); // Reset subset selection when category changes
+            const dataTypes = getDataTypesForCategory(category);
+            setDataTypes(dataTypes);
+            if (!dataTypes.includes(dataType || "")) {
+                onDataTypeChange("");
+            }
         }
     }, [category]);
 
     return (
         <Group>
-            <TextInput placeholder="Field name" />
+            <TextInput
+                value={fieldName}
+                placeholder="Field name"
+                onChange={(event) => onFieldNameChange(event.currentTarget.value !== "" ? event.currentTarget.value : null)}
+            />
             <Select
-                value={category}
+                value={category || ""}
                 allowDeselect={false}
-                onChange={setCategory}
+                onChange={(value) => onCategoryChange(value !== "" ? value : null)}
                 placeholder="Category"
-                data={getCategoryNames()} />
+                data={getCategoryNames().map((name) => ({ value: name, label: name }))}
+            />
             <Select
-                value={dataType}
-                onChange={setDataType}
-                placeholder="Subset"
-                data={categoryTypes.map(name => ({ value: name, label: name }))}
+                value={dataType || ""}
+                onChange={(value) => onDataTypeChange(value !== "" ? value : null)}
+                placeholder="Data type"
+                data={dataTypes.map((name) => ({ value: name, label: name }))}
                 disabled={!category}
             />
         </Group>
     );
-}
+};

--- a/src/Features/faker/styles.module.css
+++ b/src/Features/faker/styles.module.css
@@ -1,0 +1,4 @@
+.parent {
+  height: 100%;
+  width: 100%;
+}

--- a/src/Layout/Navbar/index.tsx
+++ b/src/Layout/Navbar/index.tsx
@@ -37,6 +37,7 @@ import {
   MdQrCode,
   MdQuestionMark,
   MdWork,
+  MdDataExploration
 } from "react-icons/md";
 import { SiJsonwebtokens, SiPostgresql, SiPrettier } from "react-icons/si";
 import {
@@ -215,6 +216,12 @@ export const data: NavItem[] = [
     to: "/regex",
     icon: <VscRegex />,
     text: "Regex Tester",
+  },
+  {
+    id: "faker",
+    to: "/faker",
+    icon: <MdDataExploration />,
+    text: "Faker",
   },
 ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,6 +1160,11 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
+"@faker-js/faker@^8.4.1":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-8.4.1.tgz#5d5e8aee8fce48f5e189bf730ebd1f758f491451"
+  integrity sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==
+
 "@fastify/busboy@^2.0.0":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.1.tgz#b9da6a878a371829a0502c9b6c1c143ef6663f4d"


### PR DESCRIPTION
This adds support for creating mock data with [Faker](https://fakerjs.dev/) as discussed in [Issue 67](https://github.com/fosslife/devtools-x/issues/67).

## Change Summary
- Added [Faker](https://fakerjs.dev/) library.
- Created a new folder called `faker` in `Features` directory.
- Created `Faker` component as the main view.
- Created `FakerInput` component to take in field name and other faker details.
- Updated `Navbar` and the main `Index` files for navigation entry and routing.
- Added the feature to `README.md`

## Notes
- When SQL is selected as output type a textbox for table name is provided.
- When CSV is selected as output type a textbox fordelimiter is provided.

## What can be improved
- [ ] Add support for locale (I tried, I just couldn't get it to work without statistically importing all Faker locales, in which case, we would have to update the code for every Faker update rather than just updating Faker version. I'll try giving it a shot later, but any help is welcomed)
- [ ] Add support for expressions. (for example, date | number > or <)
- [ ] Exporting to file (If that is even necessary).